### PR TITLE
Handle composer

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -118,7 +118,7 @@ sync_tag () {
 	git checkout "tags/$tag" > /dev/null 2>&1
 
 	echo "Composer install"
-	composer install
+	composer install --no-dev
 
 	echo "Copying files over to svn repository in folder $SVN_DIR/tags/$tag."
 	mkdir "$SVN_DIR/tags/$tag"
@@ -143,7 +143,7 @@ sync_trunk () {
 	git checkout master > /dev/null 2>&1
 
 	echo "Composer install"
-	composer install
+	composer install --no-dev
 
 	echo "Copying files over to svn repository in folder $SVN_TRUNK_DIR."
 	sync_files . "$SVN_TRUNK_DIR"
@@ -157,7 +157,7 @@ sync_assets () {
 	git checkout master > /dev/null 2>&1
 
 	echo "Composer install"
-	composer install
+	composer install --no-dev
 
 	if [ -d "$GIT_ASSETS_DIR" ]; then
 		sync_files "$GIT_ASSETS_DIR" "$SVN_ASSETS_DIR"

--- a/sync.sh
+++ b/sync.sh
@@ -117,6 +117,9 @@ sync_tag () {
 	echo "Checking out 'tags/$tag'."
 	git checkout "tags/$tag" > /dev/null 2>&1
 
+	echo "Composer install"
+	composer install
+
 	echo "Copying files over to svn repository in folder $SVN_DIR/tags/$tag."
 	mkdir "$SVN_DIR/tags/$tag"
   sync_files . "$SVN_DIR/tags/$tag"
@@ -139,6 +142,9 @@ sync_trunk () {
 	echo "Checking out master branch."
 	git checkout master > /dev/null 2>&1
 
+	echo "Composer install"
+	composer install
+
 	echo "Copying files over to svn repository in folder $SVN_TRUNK_DIR."
 	sync_files . "$SVN_TRUNK_DIR"
 
@@ -149,6 +155,9 @@ sync_trunk () {
 sync_assets () {
 	cd "$GIT_DIR" || exit
 	git checkout master > /dev/null 2>&1
+
+	echo "Composer install"
+	composer install
 
 	if [ -d "$GIT_ASSETS_DIR" ]; then
 		sync_files "$GIT_ASSETS_DIR" "$SVN_ASSETS_DIR"


### PR DESCRIPTION
Handle composer install when doing a checkout to ensure to get vendor folder.
By this process, vendor folder is added to SVN and sent to wp.org.